### PR TITLE
fix: add missing menu color definitions to medium-purple and soft-dark themes

### DIFF
--- a/themes/fexend-color-theme-medium-purple.json
+++ b/themes/fexend-color-theme-medium-purple.json
@@ -133,6 +133,20 @@
 		"titleBar.border": "#2a1f4d",
 		// TITLE BAR COLORS ------------------
 
+		// MENU BAR COLORS -------------------
+		// https://code.visualstudio.com/api/references/theme-color#menu-bar-colors
+		"menubar.selectionForeground": "#ffffff",
+		"menubar.selectionBackground": "#7c86ff20",
+		"menubar.selectionBorder": "#7c86ff",
+		"menu.foreground": "#ffffff",
+		"menu.background": "#2d2148",
+		"menu.selectionForeground": "#ffffff",
+		"menu.selectionBackground": "#7c86ff30",
+		"menu.selectionBorder": "#7c86ff",
+		"menu.separatorBackground": "#7c86ff30",
+		"menu.border": "#3d2f62",
+		// MENU BAR COLORS -------------------
+
 		// TERMINAL COLORS -------------------
 		"terminal.background": "#2d2148",
 		"terminal.border": "#3d2f62",

--- a/themes/fexend-color-theme-soft-dark.json
+++ b/themes/fexend-color-theme-soft-dark.json
@@ -188,6 +188,20 @@
 		"titleBar.border": "#1e293b",
 		// TITLE BAR COLORS ------------------
 
+		// MENU BAR COLORS -------------------
+		// https://code.visualstudio.com/api/references/theme-color#menu-bar-colors
+		"menubar.selectionForeground": "#e2e8f0",
+		"menubar.selectionBackground": "#7c86ff20",
+		"menubar.selectionBorder": "#7c86ff",
+		"menu.foreground": "#e2e8f0",
+		"menu.background": "#1e293b",
+		"menu.selectionForeground": "#e2e8f0",
+		"menu.selectionBackground": "#7c86ff30",
+		"menu.selectionBorder": "#7c86ff",
+		"menu.separatorBackground": "#7c86ff30",
+		"menu.border": "#243448",
+		// MENU BAR COLORS -------------------
+
 		// TERMINAL COLORS -------------------
 		"terminal.background": "#1e293b",
 		"terminal.border": "#243448",


### PR DESCRIPTION
The fexend-color-theme-medium-purple and fexend-color-theme-soft-dark variants were missing all menu color token definitions. Without explicit menu colors, VSCode falls back to system defaults (a light/white background on Windows) while text inherits white from the base foreground, making menu text invisible.

Fixes #19

Generated with [Claude Code](https://claude.ai/code)