### PR TITLE
feat: add comprehensive Markdown syntax highlighting to all themes

### DIFF
--- a/themes/fexend-color-theme-italic.json
+++ b/themes/fexend-color-theme-italic.json
@@ -1429,11 +1429,30 @@
 			}
 		},
 		{
+			"name": "Markdown Heading Punctuation",
+			"scope": [
+				"punctuation.definition.heading.markdown",
+				"punctuation.definition.heading.setext"
+			],
+			"settings": {
+				"foreground": "#fb7185"
+			}
+		},
+		{
 			"name": "Markdown Bold",
 			"scope": ["markup.bold"],
 			"settings": {
 				"foreground": "#fbbf24",
 				"fontStyle": "bold italic"
+			}
+		},
+		{
+			"name": "Markdown Bold Punctuation",
+			"scope": [
+				"punctuation.definition.bold.markdown"
+			],
+			"settings": {
+				"foreground": "#f59e0b"
 			}
 		},
 		{
@@ -1445,10 +1464,61 @@
 			}
 		},
 		{
+			"name": "Markdown Italic Punctuation",
+			"scope": [
+				"punctuation.definition.italic.markdown"
+			],
+			"settings": {
+				"foreground": "#22d3ee"
+			}
+		},
+		{
+			"name": "Markdown Strikethrough",
+			"scope": ["markup.strikethrough"],
+			"settings": {
+				"foreground": "#ef4444",
+				"fontStyle": "strikethrough italic"
+			}
+		},
+		{
+			"name": "Markdown Strikethrough Punctuation",
+			"scope": [
+				"punctuation.definition.strikethrough.markdown"
+			],
+			"settings": {
+				"foreground": "#ef4444"
+			}
+		},
+		{
 			"name": "Markdown Code",
-			"scope": ["markup.inline.raw", "markup.fenced_code"],
+			"scope": [
+				"markup.inline.raw",
+				"markup.fenced_code",
+				"markup.raw.block.markdown"
+			],
 			"settings": {
 				"foreground": "#10b981",
+				"fontStyle": "italic"
+			}
+		},
+		{
+			"name": "Markdown Code Punctuation",
+			"scope": [
+				"punctuation.definition.raw.markdown",
+				"punctuation.definition.markdown"
+			],
+			"settings": {
+				"foreground": "#10b981"
+			}
+		},
+		{
+			"name": "Markdown Code Fence Language",
+			"scope": [
+				"fenced_code.block.language.markdown",
+				"markup.fenced_code.block.markdown"
+			],
+			"settings": {
+				"foreground": "#fbbf24",
 				"fontStyle": "italic"
 			}
 		},
@@ -1458,6 +1528,73 @@
 			"settings": {
 				"foreground": "#06b6d4",
 				"fontStyle": "italic"
+			}
+		},
+		{
+			"name": "Markdown Link Title",
+			"scope": [
+				"string.other.link.title.markdown",
+				"meta.link.inline.markdown"
+			],
+			"settings": {
+				"foreground": "#7c86ff",
+				"fontStyle": "italic"
+			}
+		},
+		{
+			"name": "Markdown Link Punctuation",
+			"scope": [
+				"punctuation.definition.link.markdown",
+				"punctuation.definition.string.begin.markdown",
+				"punctuation.definition.string.end.markdown",
+				"punctuation.definition.metadata.markdown"
+			],
+			"settings": {
+				"foreground": "#94a3b8"
+			}
+		},
+		{
+			"name": "Markdown List Markers",
+			"scope": [
+				"markup.list",
+				"punctuation.definition.list.begin.markdown"
+			],
+			"settings": {
+				"foreground": "#fb7185"
+			}
+		},
+		{
+			"name": "Markdown Blockquote",
+			"scope": ["markup.quote"],
+			"settings": {
+				"foreground": "#94a3b8",
+				"fontStyle": "italic"
+			}
+		},
+		{
+			"name": "Markdown Blockquote Marker",
+			"scope": [
+				"punctuation.definition.quote.begin.markdown"
+			],
+			"settings": {
+				"foreground": "#64748b"
+			}
+		},
+		{
+			"name": "Markdown Horizontal Rule",
+			"scope": ["meta.separator.markdown"],
+			"settings": {
+				"foreground": "#475569"
+			}
+		},
+		{
+			"name": "Markdown Table Pipes",
+			"scope": [
+				"punctuation.separator.table-cell.markdown",
+				"punctuation.section.table-header.markdown"
+			],
+			"settings": {
+				"foreground": "#64748b"
 			}
 		},
 		{

--- a/themes/fexend-color-theme-medium-purple.json
+++ b/themes/fexend-color-theme-medium-purple.json
@@ -451,6 +451,179 @@
 			}
 		},
 		{
+			"name": "Markdown Headings",
+			"scope": ["markup.heading", "entity.name.section.markdown"],
+			"settings": {
+				"foreground": "#f97316",
+				"fontStyle": "bold"
+			}
+		},
+		{
+			"name": "Markdown Heading Punctuation",
+			"scope": [
+				"punctuation.definition.heading.markdown",
+				"punctuation.definition.heading.setext"
+			],
+			"settings": {
+				"foreground": "#fb7185"
+			}
+		},
+		{
+			"name": "Markdown Bold",
+			"scope": ["markup.bold"],
+			"settings": {
+				"foreground": "#fbbf24",
+				"fontStyle": "bold"
+			}
+		},
+		{
+			"name": "Markdown Bold Punctuation",
+			"scope": [
+				"punctuation.definition.bold.markdown"
+			],
+			"settings": {
+				"foreground": "#f59e0b"
+			}
+		},
+		{
+			"name": "Markdown Italic",
+			"scope": ["markup.italic"],
+			"settings": {
+				"foreground": "#22d3ee",
+				"fontStyle": "italic"
+			}
+		},
+		{
+			"name": "Markdown Italic Punctuation",
+			"scope": [
+				"punctuation.definition.italic.markdown"
+			],
+			"settings": {
+				"foreground": "#22d3ee"
+			}
+		},
+		{
+			"name": "Markdown Strikethrough",
+			"scope": ["markup.strikethrough"],
+			"settings": {
+				"foreground": "#ef4444",
+				"fontStyle": "strikethrough"
+			}
+		},
+		{
+			"name": "Markdown Strikethrough Punctuation",
+			"scope": [
+				"punctuation.definition.strikethrough.markdown"
+			],
+			"settings": {
+				"foreground": "#ef4444"
+			}
+		},
+		{
+			"name": "Markdown Code",
+			"scope": [
+				"markup.inline.raw",
+				"markup.fenced_code",
+				"markup.raw.block.markdown"
+			],
+			"settings": {
+				"foreground": "#34d399"
+			}
+		},
+		{
+			"name": "Markdown Code Punctuation",
+			"scope": [
+				"punctuation.definition.raw.markdown",
+				"punctuation.definition.markdown"
+			],
+			"settings": {
+				"foreground": "#34d399"
+			}
+		},
+		{
+			"name": "Markdown Code Fence Language",
+			"scope": [
+				"fenced_code.block.language.markdown",
+				"markup.fenced_code.block.markdown"
+			],
+			"settings": {
+				"foreground": "#fbbf24"
+			}
+		},
+		{
+			"name": "Markdown Links",
+			"scope": ["markup.underline.link"],
+			"settings": {
+				"foreground": "#67e8f9"
+			}
+		},
+		{
+			"name": "Markdown Link Title",
+			"scope": [
+				"string.other.link.title.markdown",
+				"meta.link.inline.markdown"
+			],
+			"settings": {
+				"foreground": "#c27aff"
+			}
+		},
+		{
+			"name": "Markdown Link Punctuation",
+			"scope": [
+				"punctuation.definition.link.markdown",
+				"punctuation.definition.string.begin.markdown",
+				"punctuation.definition.string.end.markdown",
+				"punctuation.definition.metadata.markdown"
+			],
+			"settings": {
+				"foreground": "#94a3b8"
+			}
+		},
+		{
+			"name": "Markdown List Markers",
+			"scope": [
+				"markup.list",
+				"punctuation.definition.list.begin.markdown"
+			],
+			"settings": {
+				"foreground": "#fb7185"
+			}
+		},
+		{
+			"name": "Markdown Blockquote",
+			"scope": ["markup.quote"],
+			"settings": {
+				"foreground": "#94a3b8",
+				"fontStyle": "italic"
+			}
+		},
+		{
+			"name": "Markdown Blockquote Marker",
+			"scope": [
+				"punctuation.definition.quote.begin.markdown"
+			],
+			"settings": {
+				"foreground": "#64748b"
+			}
+		},
+		{
+			"name": "Markdown Horizontal Rule",
+			"scope": ["meta.separator.markdown"],
+			"settings": {
+				"foreground": "#475569"
+			}
+		},
+		{
+			"name": "Markdown Table Pipes",
+			"scope": [
+				"punctuation.separator.table-cell.markdown",
+				"punctuation.section.table-header.markdown"
+			],
+			"settings": {
+				"foreground": "#64748b"
+			}
+		},
+		{
 			"name": "HTML Tags",
 			"scope": ["entity.name.tag", "meta.tag", "punctuation.definition.tag"],
 			"settings": {

--- a/themes/fexend-color-theme-soft-dark.json
+++ b/themes/fexend-color-theme-soft-dark.json
@@ -503,6 +503,179 @@
 			}
 		},
 		{
+			"name": "Markdown Headings",
+			"scope": ["markup.heading", "entity.name.section.markdown"],
+			"settings": {
+				"foreground": "#f97316",
+				"fontStyle": "bold"
+			}
+		},
+		{
+			"name": "Markdown Heading Punctuation",
+			"scope": [
+				"punctuation.definition.heading.markdown",
+				"punctuation.definition.heading.setext"
+			],
+			"settings": {
+				"foreground": "#fb7185"
+			}
+		},
+		{
+			"name": "Markdown Bold",
+			"scope": ["markup.bold"],
+			"settings": {
+				"foreground": "#fbbf24",
+				"fontStyle": "bold"
+			}
+		},
+		{
+			"name": "Markdown Bold Punctuation",
+			"scope": [
+				"punctuation.definition.bold.markdown"
+			],
+			"settings": {
+				"foreground": "#f59e0b"
+			}
+		},
+		{
+			"name": "Markdown Italic",
+			"scope": ["markup.italic"],
+			"settings": {
+				"foreground": "#22d3ee",
+				"fontStyle": "italic"
+			}
+		},
+		{
+			"name": "Markdown Italic Punctuation",
+			"scope": [
+				"punctuation.definition.italic.markdown"
+			],
+			"settings": {
+				"foreground": "#22d3ee"
+			}
+		},
+		{
+			"name": "Markdown Strikethrough",
+			"scope": ["markup.strikethrough"],
+			"settings": {
+				"foreground": "#ef4444",
+				"fontStyle": "strikethrough"
+			}
+		},
+		{
+			"name": "Markdown Strikethrough Punctuation",
+			"scope": [
+				"punctuation.definition.strikethrough.markdown"
+			],
+			"settings": {
+				"foreground": "#ef4444"
+			}
+		},
+		{
+			"name": "Markdown Code",
+			"scope": [
+				"markup.inline.raw",
+				"markup.fenced_code",
+				"markup.raw.block.markdown"
+			],
+			"settings": {
+				"foreground": "#34d399"
+			}
+		},
+		{
+			"name": "Markdown Code Punctuation",
+			"scope": [
+				"punctuation.definition.raw.markdown",
+				"punctuation.definition.markdown"
+			],
+			"settings": {
+				"foreground": "#34d399"
+			}
+		},
+		{
+			"name": "Markdown Code Fence Language",
+			"scope": [
+				"fenced_code.block.language.markdown",
+				"markup.fenced_code.block.markdown"
+			],
+			"settings": {
+				"foreground": "#fbbf24"
+			}
+		},
+		{
+			"name": "Markdown Links",
+			"scope": ["markup.underline.link"],
+			"settings": {
+				"foreground": "#38bdf8"
+			}
+		},
+		{
+			"name": "Markdown Link Title",
+			"scope": [
+				"string.other.link.title.markdown",
+				"meta.link.inline.markdown"
+			],
+			"settings": {
+				"foreground": "#7c86ff"
+			}
+		},
+		{
+			"name": "Markdown Link Punctuation",
+			"scope": [
+				"punctuation.definition.link.markdown",
+				"punctuation.definition.string.begin.markdown",
+				"punctuation.definition.string.end.markdown",
+				"punctuation.definition.metadata.markdown"
+			],
+			"settings": {
+				"foreground": "#94a3b8"
+			}
+		},
+		{
+			"name": "Markdown List Markers",
+			"scope": [
+				"markup.list",
+				"punctuation.definition.list.begin.markdown"
+			],
+			"settings": {
+				"foreground": "#fb7185"
+			}
+		},
+		{
+			"name": "Markdown Blockquote",
+			"scope": ["markup.quote"],
+			"settings": {
+				"foreground": "#94a3b8",
+				"fontStyle": "italic"
+			}
+		},
+		{
+			"name": "Markdown Blockquote Marker",
+			"scope": [
+				"punctuation.definition.quote.begin.markdown"
+			],
+			"settings": {
+				"foreground": "#64748b"
+			}
+		},
+		{
+			"name": "Markdown Horizontal Rule",
+			"scope": ["meta.separator.markdown"],
+			"settings": {
+				"foreground": "#475569"
+			}
+		},
+		{
+			"name": "Markdown Table Pipes",
+			"scope": [
+				"punctuation.separator.table-cell.markdown",
+				"punctuation.section.table-header.markdown"
+			],
+			"settings": {
+				"foreground": "#64748b"
+			}
+		},
+		{
 			"name": "HTML Tags",
 			"scope": ["entity.name.tag", "meta.tag", "punctuation.definition.tag"],
 			"settings": {

--- a/themes/fexend-color-theme.json
+++ b/themes/fexend-color-theme.json
@@ -1410,11 +1410,30 @@
 			}
 		},
 		{
+			"name": "Markdown Heading Punctuation",
+			"scope": [
+				"punctuation.definition.heading.markdown",
+				"punctuation.definition.heading.setext"
+			],
+			"settings": {
+				"foreground": "#fb7185"
+			}
+		},
+		{
 			"name": "Markdown Bold",
 			"scope": ["markup.bold"],
 			"settings": {
 				"foreground": "#fbbf24",
 				"fontStyle": "bold"
+			}
+		},
+		{
+			"name": "Markdown Bold Punctuation",
+			"scope": [
+				"punctuation.definition.bold.markdown"
+			],
+			"settings": {
+				"foreground": "#f59e0b"
 			}
 		},
 		{
@@ -1426,10 +1445,60 @@
 			}
 		},
 		{
+			"name": "Markdown Italic Punctuation",
+			"scope": [
+				"punctuation.definition.italic.markdown"
+			],
+			"settings": {
+				"foreground": "#22d3ee"
+			}
+		},
+		{
+			"name": "Markdown Strikethrough",
+			"scope": ["markup.strikethrough"],
+			"settings": {
+				"foreground": "#ef4444",
+				"fontStyle": "strikethrough"
+			}
+		},
+		{
+			"name": "Markdown Strikethrough Punctuation",
+			"scope": [
+				"punctuation.definition.strikethrough.markdown"
+			],
+			"settings": {
+				"foreground": "#ef4444"
+			}
+		},
+		{
 			"name": "Markdown Code",
-			"scope": ["markup.inline.raw", "markup.fenced_code"],
+			"scope": [
+				"markup.inline.raw",
+				"markup.fenced_code",
+				"markup.raw.block.markdown"
+			],
 			"settings": {
 				"foreground": "#10b981"
+			}
+		},
+		{
+			"name": "Markdown Code Punctuation",
+			"scope": [
+				"punctuation.definition.raw.markdown",
+				"punctuation.definition.markdown"
+			],
+			"settings": {
+				"foreground": "#10b981"
+			}
+		},
+		{
+			"name": "Markdown Code Fence Language",
+			"scope": [
+				"fenced_code.block.language.markdown",
+				"markup.fenced_code.block.markdown"
+			],
+			"settings": {
+				"foreground": "#fbbf24"
 			}
 		},
 		{
@@ -1437,6 +1506,72 @@
 			"scope": ["markup.underline.link"],
 			"settings": {
 				"foreground": "#06b6d4"
+			}
+		},
+		{
+			"name": "Markdown Link Title",
+			"scope": [
+				"string.other.link.title.markdown",
+				"meta.link.inline.markdown"
+			],
+			"settings": {
+				"foreground": "#7c86ff"
+			}
+		},
+		{
+			"name": "Markdown Link Punctuation",
+			"scope": [
+				"punctuation.definition.link.markdown",
+				"punctuation.definition.string.begin.markdown",
+				"punctuation.definition.string.end.markdown",
+				"punctuation.definition.metadata.markdown"
+			],
+			"settings": {
+				"foreground": "#94a3b8"
+			}
+		},
+		{
+			"name": "Markdown List Markers",
+			"scope": [
+				"markup.list",
+				"punctuation.definition.list.begin.markdown"
+			],
+			"settings": {
+				"foreground": "#fb7185"
+			}
+		},
+		{
+			"name": "Markdown Blockquote",
+			"scope": ["markup.quote"],
+			"settings": {
+				"foreground": "#94a3b8",
+				"fontStyle": "italic"
+			}
+		},
+		{
+			"name": "Markdown Blockquote Marker",
+			"scope": [
+				"punctuation.definition.quote.begin.markdown"
+			],
+			"settings": {
+				"foreground": "#64748b"
+			}
+		},
+		{
+			"name": "Markdown Horizontal Rule",
+			"scope": ["meta.separator.markdown"],
+			"settings": {
+				"foreground": "#475569"
+			}
+		},
+		{
+			"name": "Markdown Table Pipes",
+			"scope": [
+				"punctuation.separator.table-cell.markdown",
+				"punctuation.section.table-header.markdown"
+			],
+			"settings": {
+				"foreground": "#64748b"
 			}
 		},
 		{


### PR DESCRIPTION
Adds comprehensive markdown token highlighting across all 4 theme variants.

The soft-dark and medium-purple themes had no markdown rules at all — now they do. The main and italic themes have been expanded with more granular token coverage.

Closes #20

Generated with [Claude Code](https://claude.ai/code)